### PR TITLE
docs: point site + all URLs at mokata.ai

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
       "version": "0.0.12",
       "description": "Spec-driven TDD framework: brainstorm -> provable completeness gate -> RED-before-GREEN -> review, with a codebase knowledge graph, self-healing memory, token governance, and human-gated writes. Local-first, Apache-2.0.",
       "license": "Apache-2.0",
-      "homepage": "https://jasgujral.github.io/mokata-oss/"
+      "homepage": "https://mokata.ai/"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "MoStack"
   },
-  "homepage": "https://jasgujral.github.io/mokata-oss/",
+  "homepage": "https://mokata.ai/",
   "repository": "https://github.com/JasGujral/mokata-oss",
   "license": "Apache-2.0",
   "keywords": [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thanks for helping build mokata. This project has a few firm rules — they're what make it
 trustworthy.
 
-Full documentation: <https://jasgujral.github.io/mokata-oss/>.
+Full documentation: <https://mokata.ai/>.
 
 ## Dev setup
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ stops the agent shipping the wrong thing.
 [![CI](https://github.com/JasGujral/mokata-oss/actions/workflows/ci.yml/badge.svg)](https://github.com/JasGujral/mokata-oss/actions/workflows/ci.yml)
 [![Version](https://img.shields.io/github/v/release/JasGujral/mokata-oss?label=version)](https://github.com/JasGujral/mokata-oss/releases/latest)
 [![Python](https://img.shields.io/badge/python-3.10%E2%80%933.13-blue.svg)](pyproject.toml)
-[![Docs](https://img.shields.io/badge/docs-mkdocs-blue.svg)](https://jasgujral.github.io/mokata-oss/)
+[![Docs](https://img.shields.io/badge/docs-mkdocs-blue.svg)](https://mokata.ai/)
 [![local-first](https://img.shields.io/badge/local--first-no%20telemetry-success.svg)](docs/concepts/governance.md)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/JasGujral/mokata-oss/badge)](https://securityscorecards.dev/viewer/?uri=github.com/JasGujral/mokata-oss)
 
-📖 **Full documentation:** **<https://jasgujral.github.io/mokata-oss/>** — quickstart, tutorials, concepts, and the complete CLI + plugin reference.
+📖 **Full documentation:** **<https://mokata.ai/>** — quickstart, tutorials, concepts, and the complete CLI + plugin reference.
 
 ---
 
@@ -99,7 +99,7 @@ See [Integrate with other AI tools](docs/how-to/integrate-other-ai-tools.md).
 > **planned, not yet available** — mokata isn't registered on any Claude Code marketplace.
 > The supported way to run mokata inside Claude Code today is the pip-first path:
 > `pip install mokata` → `mokata setup claude`
-> (see [Getting started](https://jasgujral.github.io/mokata-oss/getting-started/)).
+> (see [Getting started](https://mokata.ai/getting-started/)).
 > _(This notice auto-flips once the listing is approved — single source:
 > `scripts/directory_listing.py`.)_
 <!-- mokata:directory-listing:end -->
@@ -129,9 +129,9 @@ mokata playbook                     # drive the full story end-to-end through th
 
 > A `pip` CLI install is **terminal-only** — it runs the deterministic engine with no LLM
 > attached. It does **not** put mokata inside Claude Code; for that, install the plugin or run
-> `mokata setup claude`. ([Why two ways](https://jasgujral.github.io/mokata-oss/concepts/execution-model/).)
+> `mokata setup claude`. ([Why two ways](https://mokata.ai/concepts/execution-model/).)
 
-Full walkthrough: [`docs/quickstart.md`](docs/quickstart.md) · full hands-on guide → [the Complete Guide](https://jasgujral.github.io/mokata-oss/tutorials/mokata-complete-guide/) (with a downloadable PDF) · published docs: <https://jasgujral.github.io/mokata-oss/>
+Full walkthrough: [`docs/quickstart.md`](docs/quickstart.md) · full hands-on guide → [the Complete Guide](https://mokata.ai/tutorials/mokata-complete-guide/) (with a downloadable PDF) · published docs: <https://mokata.ai/>
 
 ## Core concepts
 
@@ -169,7 +169,7 @@ The CLI exposes 40+ subcommands, including:
 - **Team, stacks & sharing** — `team` (`init`/`join`/`adopt`/`connect`/`disconnect`), `mode`, `sync`, `stacks` (`list`/`search`/`show`/`install`), `vault`.
 - **Setup, config & distribution** — `init`, `setup`/`unsetup`, `reconfigure`, `tour`, `config`, `bootstrap`, `validate`, `route`, `detect`, `reset`, `suggest`, `mcp`, `ci-check`, `export`/`import`, `version`/`upgrade`, `release-check`.
 
-Full list with flags: the [CLI reference](https://jasgujral.github.io/mokata-oss/reference/cli/).
+Full list with flags: the [CLI reference](https://mokata.ai/reference/cli/).
 
 ## Contributing · Security · License
 
@@ -180,6 +180,6 @@ Full list with flags: the [CLI reference](https://jasgujral.github.io/mokata-oss
 
 ## Links
 
-- **Documentation: <https://jasgujral.github.io/mokata-oss/>** (the published docs site; source in `docs/`, built with MkDocs)
+- **Documentation: <https://mokata.ai/>** (the published docs site; source in `docs/`, built with MkDocs)
 - Changelog: [`CHANGELOG.md`](CHANGELOG.md)
 - Issues & discussions: the repository's Issues / Discussions tabs

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 # Security Policy
 
-Documentation: <https://jasgujral.github.io/mokata-oss/> ·
-Supply-chain details: <https://jasgujral.github.io/mokata-oss/reference/supply-chain/>
+Documentation: <https://mokata.ai/> ·
+Supply-chain details: <https://mokata.ai/reference/supply-chain/>
 
 mokata follows a **coordinated (responsible) disclosure** policy: report privately, we
 investigate and fix, and we disclose together once a fix is available.
@@ -63,7 +63,7 @@ performs **zero network egress**.
 ## Verifying a release (supply chain)
 
 Releases are built in CI at tag time with three trust signals (see the
-[supply-chain reference](https://jasgujral.github.io/mokata-oss/reference/supply-chain/)):
+[supply-chain reference](https://mokata.ai/reference/supply-chain/)):
 
 - **Build-provenance attestation** (Sigstore / SLSA) — verify a downloaded artifact with:
 

--- a/docs/assets/brand/pdf-cover.html
+++ b/docs/assets/brand/pdf-cover.html
@@ -7,5 +7,5 @@
 </div>
   <h1 style="font-family:'DejaVu Sans Mono',monospace; font-size:28px; margin-top:24px;">The Complete Guide</h1>
   <p style="font-size:15px; color:#444;">The memory + seatbelt for your AI coding agent.</p>
-  <p style="font-size:12px; color:#888;">Spec-driven TDD for Claude Code — knowledge-aware, human-gated, local-first.<br/>jasgujral.github.io/mokata-oss · Apache-2.0 · © MoStack</p>
+  <p style="font-size:12px; color:#888;">Spec-driven TDD for Claude Code — knowledge-aware, human-gated, local-first.<br/>mokata.ai · Apache-2.0 · © MoStack</p>
 </div>

--- a/docs/how-to/install-plugin.md
+++ b/docs/how-to/install-plugin.md
@@ -5,7 +5,7 @@
 > **planned, not yet available** — mokata isn't registered on any Claude Code marketplace.
 > The supported way to run mokata inside Claude Code today is the pip-first path:
 > `pip install mokata` → `mokata setup claude`
-> (see [Getting started](https://jasgujral.github.io/mokata-oss/getting-started/)).
+> (see [Getting started](https://mokata.ai/getting-started/)).
 > _(This notice auto-flips once the listing is approved — single source:
 > `scripts/directory_listing.py`.)_
 <!-- mokata:directory-listing:end -->

--- a/docs/how-to/use-the-plugin.md
+++ b/docs/how-to/use-the-plugin.md
@@ -15,7 +15,7 @@ mechanics for scripting and inspection outside any harness, not the primary way 
 > **planned, not yet available** — mokata isn't registered on any Claude Code marketplace.
 > The supported way to run mokata inside Claude Code today is the pip-first path:
 > `pip install mokata` → `mokata setup claude`
-> (see [Getting started](https://jasgujral.github.io/mokata-oss/getting-started/)).
+> (see [Getting started](https://mokata.ai/getting-started/)).
 > _(This notice auto-flips once the listing is approved — single source:
 > `scripts/directory_listing.py`.)_
 <!-- mokata:directory-listing:end -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,5 +70,5 @@ This site follows the [Diátaxis](https://diataxis.fr/) model:
 | K | Config | per-layer/tool toggles, profiles, local-first, committed config, trust dial, doctor, reset |
 | L | Composability | standalone commands, mid-pipeline entry, direct skills, catalog, chaining, suggestions |
 
-Published docs: <https://jasgujral.github.io/mokata-oss/> · Source & issues:
+Published docs: <https://mokata.ai/> · Source & issues:
 <https://github.com/JasGujral/mokata-oss>.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -56,7 +56,7 @@ inspection, and wiring into other harnesses rather than writing code on its own.
 > **planned, not yet available** — mokata isn't registered on any Claude Code marketplace.
 > The supported way to run mokata inside Claude Code today is the pip-first path:
 > `pip install mokata` → `mokata setup claude`
-> (see [Getting started](https://jasgujral.github.io/mokata-oss/getting-started/)).
+> (see [Getting started](https://mokata.ai/getting-started/)).
 > _(This notice auto-flips once the listing is approved — single source:
 > `scripts/directory_listing.py`.)_
 <!-- mokata:directory-listing:end -->

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -533,7 +533,7 @@ hand-maintained list). Colour + a Unicode box on a real terminal; plain-ASCII wi
 escape codes when piped, redirected, or `NO_COLOR` is set. Backs `/mokata:menu`.
 
 ### `mokata docs [topic]`
-A **pointer to the published docs site** (<https://jasgujral.github.io/mokata-oss/>). With no
+A **pointer to the published docs site** (<https://mokata.ai/>). With no
 topic it lists the top-level topics with their site URLs; with a topic (e.g. `getting-started`,
 `concepts/execution-model`) it prints that page's URL and title. **Read-only and local-first** —
 it resolves and prints URLs, it **never fetches** the page, and **no doc content ships in the

--- a/docs/tutorials/mokata-complete-guide.md
+++ b/docs/tutorials/mokata-complete-guide.md
@@ -2,7 +2,7 @@
 
 **A deep, feature-by-feature tutorial for developers. Every command, gate, layer, and toggle — from `init` to a full governed story, with nothing left out.**
 
-[**⬇ Download this guide as a PDF**](https://jasgujral.github.io/mokata-oss/assets/mokata-complete-guide.pdf) — generated from this page in CI, so it always matches what you're reading.
+[**⬇ Download this guide as a PDF**](https://mokata.ai/assets/mokata-complete-guide.pdf) — generated from this page in CI, so it always matches what you're reading.
 
 > Audience: developers who want to use mokata to its full capacity. This is a **hands-on tutorial** — you'll install the full stack with **every optional dependency wired**, verify each capability resolves to a real provider (not a fallback floor), then take a **guided power tour** that exercises every layer with the commands to run and the output to expect.
 >
@@ -284,7 +284,7 @@ Restart Claude Code. You now have the workflow slash commands (`/mokata:brainsto
 > **planned, not yet available** — mokata isn't registered on any Claude Code marketplace.
 > The supported way to run mokata inside Claude Code today is the pip-first path:
 > `pip install mokata` → `mokata setup claude`
-> (see [Getting started](https://jasgujral.github.io/mokata-oss/getting-started/)).
+> (see [Getting started](https://mokata.ai/getting-started/)).
 > _(This notice auto-flips once the listing is approved — single source:
 > `scripts/directory_listing.py`.)_
 <!-- mokata:directory-listing:end -->
@@ -1342,4 +1342,4 @@ Per-tool backend config (Stage 24A): `tools.sqlite.config.path`, `tools.obsidian
 
 ---
 
-*Built clean-room, Apache-2.0, © MoStack. Framework: **mokata** · brand: **MoStack**. Published docs: <https://jasgujral.github.io/mokata-oss/>.*
+*Built clean-room, Apache-2.0, © MoStack. Framework: **mokata** · brand: **MoStack**. Published docs: <https://mokata.ai/>.*

--- a/llms.txt
+++ b/llms.txt
@@ -47,7 +47,7 @@ The schema is owned and created only by `mokata team init` (runtime never runs D
 
 ## Documentation
 
-- Full docs: https://jasgujral.github.io/mokata-oss/
+- Full docs: https://mokata.ai/
 - Source: https://github.com/JasGujral/mokata-oss
 - Quickstart: docs/quickstart.md
 - Getting started: docs/getting-started.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_description: >-
   The memory + seatbelt for your AI coding agent. Spec-driven TDD for
   Claude Code — knowledge-aware, human-gated, local-first.
 repo_url: https://github.com/JasGujral/mokata-oss
-site_url: https://jasgujral.github.io/mokata-oss/
+site_url: https://mokata.ai/
 copyright: "© MoStack — Apache-2.0"
 
 theme:

--- a/scripts/directory_listing.py
+++ b/scripts/directory_listing.py
@@ -40,7 +40,7 @@ PENDING = (
     "> **planned, not yet available** — mokata isn't registered on any Claude Code marketplace.\n"
     "> The supported way to run mokata inside Claude Code today is the pip-first path:\n"
     "> `pip install mokata` → `mokata setup claude`\n"
-    "> (see [Getting started](https://jasgujral.github.io/mokata-oss/getting-started/)).\n"
+    "> (see [Getting started](https://mokata.ai/getting-started/)).\n"
     "> _(This notice auto-flips once the listing is approved — single source:\n"
     "> `scripts/directory_listing.py`.)_"
 )

--- a/src/mokata/product_docs.py
+++ b/src/mokata/product_docs.py
@@ -22,7 +22,7 @@ from typing import List, Optional, Tuple
 from .legibility import _color_enabled, box, table
 
 # The published documentation site (mkdocs site_url). The ONLY place docs content lives online.
-BASE_URL = "https://jasgujral.github.io/mokata-oss/"
+BASE_URL = "https://mokata.ai/"
 
 
 @dataclass(frozen=True)

--- a/src/mokata/team_docs.py
+++ b/src/mokata/team_docs.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 # The published docs site (mkdocs `site_url`) + the ops page's slug. `team-setup.md` renders at
 # `/how-to/team-setup/`; its `## Security` heading anchors at `#security`.
-DOCS_SITE = "https://jasgujral.github.io/mokata-oss"
+DOCS_SITE = "https://mokata.ai"
 TEAM_DOCS_URL = f"{DOCS_SITE}/how-to/team-setup/"
 TEAM_DOCS_SECURITY_URL = f"{TEAM_DOCS_URL}#security"
 

--- a/src/mokata/templates/commands/docs.md
+++ b/src/mokata/templates/commands/docs.md
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read
 # mokata · docs (point at the published docs site)
 
 Point the user at mokata's **published documentation site**
-(<https://jasgujral.github.io/mokata-oss/>). With **no argument** it prints the list of top-level
+(<https://mokata.ai/>). With **no argument** it prints the list of top-level
 topics, each with its live-site URL; with a **topic** it prints that page's URL. It is
 **read-only and local-first** — it resolves a topic to a URL and prints it. It **never fetches**
 the page and it ships **no doc content** in the package.
@@ -40,7 +40,7 @@ list, notes the miss, and exits non-zero — offer the closest topic from the li
 
 The topic list is a small, curated map of the top-level guides and one landing page per docs
 section. For anything not listed, point the user at the full site:
-<https://jasgujral.github.io/mokata-oss/>.
+<https://mokata.ai/>.
 
 ## Notes
 

--- a/tests/test_docs_cmd.py
+++ b/tests/test_docs_cmd.py
@@ -23,7 +23,7 @@ DOCS_DIR = os.path.join(ROOT, "docs")
 CMDS_DIR = os.path.join(ROOT, "src", "mokata", "templates", "commands")
 
 ESC = "\x1b["
-BASE = "https://jasgujral.github.io/mokata-oss/"
+BASE = "https://mokata.ai/"
 
 # Immediate subdirs of docs/ that are INTERNAL planning or mkdocs presentation, never product
 # topics. Everything else under docs/ is a public product section the pointer must cover.


### PR DESCRIPTION
Domain-only; no version bump.