### PR TITLE
Release 0.0.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,23 @@ jobs:
         os: ["ubuntu-latest", "windows-latest"]
         python: ["3.12"]
         jsonschema: ["absent", "present"]
+        # THE DECLARED FLOOR, exercised on the PR gate. `requires-python = ">=3.10"` in
+        # pyproject.toml is a promise to users, and until 0.0.16 the ONLY job that ever ran 3.10
+        # was release.yml — so the floor was first exercised at TAG time, after the code was
+        # already declared done. That is how the ISO-dialect split shipped green: `fromisoformat`
+        # learned '…Z' in 3.11, the fault only exists BELOW the CI floor, and a 3.12-only gate is
+        # structurally blind to every such gap.
+        #
+        # Deliberately ONE leg via `include`, not a Python axis: adding "3.10" to `python:` above
+        # would cross-product to 8 legs and roughly double a gate that is already ~45 min.
+        # ubuntu (cheapest runner) × jsonschema=present (the fuller dependency surface — the
+        # `absent` axis is about optional-dep degradation, which is orthogonal to interpreter
+        # version). One leg is not full floor coverage and is not claimed to be; broader matrix
+        # work is tracked as CI-MATRIX-FLOOR-GAP in doc 84.
+        include:
+          - os: "ubuntu-latest"
+            python: "3.10"
+            jsonschema: "present"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/src/mokata/memory/item.py
+++ b/src/mokata/memory/item.py
@@ -291,8 +291,21 @@ def now_iso() -> str:
 
 
 def add_seconds(iso: str, seconds: int) -> str:
-    dt = datetime.fromisoformat(iso)
-    return (dt + timedelta(seconds=seconds)).isoformat()
+    """`iso` advanced by `seconds`, as an ISO-8601 string. Raises on a malformed stamp.
+
+    Lexes through `lifecycle.parse_iso_strict` — THE one ISO lexer — rather than calling
+    `fromisoformat` directly, so a `…Z` stamp is read here exactly as the healing and ranking paths
+    read it. Keeps its raising contract: this builds an `expires_at` from a caller-supplied
+    `created_at`, and a TTL silently computed off a stamp we could not read is worse than a loud
+    failure at the write.
+
+    Imported inside the function, not at module scope: `lifecycle` imports THIS module, so a
+    top-level import is a genuine circular import (`memory/__init__` loads lifecycle first, which
+    would find `item` half-built). One lexer, imported late — not a second copy of it.
+    """
+    from .lifecycle import parse_iso_strict
+
+    return (parse_iso_strict(iso) + timedelta(seconds=seconds)).isoformat()
 
 
 @dataclass

--- a/src/mokata/memory/lifecycle.py
+++ b/src/mokata/memory/lifecycle.py
@@ -97,6 +97,49 @@ USAGE_SATURATION_HITS = 5.0
 _SECONDS_PER_DAY = 86400.0
 
 
+# ------------------------------------------------------------------ the ONE ISO lexer
+# THE dialect gap, and why this is a lexer rather than a try/except: `datetime.fromisoformat` only
+# learned the Zulu designator ('…Z') in Python 3.11. mokata's declared floor is 3.10, where every
+# `…Z` stamp — the dialect Postgres, a teammate's client and half the ISO-8601 world emit — raises
+# ValueError. At the ranking inputs below that fault is SILENT: `parse_iso` absorbs it to None, the
+# term degrades to 0.0, and a recency signal that exists simply stops counting. Nothing logs, no
+# test fails, and the ordering is quietly wrong on the interpreter the package claims to support.
+#
+# It is normalized UNCONDITIONALLY — no `sys.version_info` branch anywhere in this path. A
+# version-gated fix ships two lexers and guarantees that whichever one CI does not run is the one
+# that rots; an unconditional rewrite means 3.10 and 3.12 lex the same bytes the same way, so a
+# test that passes on either is evidence about both. On 3.11+ the rewrite is a no-op in meaning:
+# '+00:00' is what that interpreter already parses '…Z' into.
+_ZULU = ("Z", "z")
+_UTC_OFFSET = "+00:00"
+
+
+def _normalize_iso(value: Any) -> Any:
+    """`value` with a trailing Zulu designator rewritten to the explicit `+00:00` offset.
+
+    Byte-identical passthrough for EVERYTHING else — an already-explicit `+00:00`, any other
+    offset, a naive stamp, a non-string, the empty string. It corrects one dialect; it does not
+    validate, repair or canonicalize, so a malformed stamp stays malformed and still raises
+    downstream where the caller's contract decides what that means.
+    """
+    if not isinstance(value, str):
+        return value
+    if len(value) > 1 and value[-1] in _ZULU:
+        return value[:-1] + _UTC_OFFSET
+    return value
+
+
+def parse_iso_strict(value: Any) -> datetime:
+    """An ISO-8601 timestamp as an aware datetime. RAISES on genuinely malformed input.
+
+    The raising half of the pair, for callers whose contract is "this stamp is well-formed and a
+    bad one is a bug" rather than "degrade to no signal". A naive timestamp is read as UTC, matching
+    `item.now_iso`, so mixed-offset stores compare correctly.
+    """
+    dt = datetime.fromisoformat(_normalize_iso(str(value)))
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
+
 def parse_iso(value: Any) -> Optional[datetime]:
     """An ISO-8601 timestamp as an aware datetime, or None for anything unparseable.
 
@@ -104,14 +147,22 @@ def parse_iso(value: Any) -> Optional[datetime]:
     hand-editable doc and a teammate's client, so a malformed one must degrade to "no signal"
     (score 0.0 — the back-compat floor) instead of failing a recall. A naive timestamp is read as
     UTC, matching `item.now_iso`, so mixed-offset stores compare correctly.
+
+    WHY THE ABSORBER IS SAFE NOW, which it was not before: an absorber at a ranking input cannot
+    tell "this stamp is garbage" from "this interpreter cannot read this dialect", and it answers
+    both with the same silent 0.0. That is fine for the first and a correctness bug for the second.
+    `_normalize_iso` closes the Zulu case AHEAD of the absorber, so the one dialect gap that used to
+    reach it — and the only one mokata's own writers and Postgres actually emit — no longer can.
+    The absorber is back to meaning what it says: this input was malformed. It is NOT a general
+    dialect shim, and the remaining 3.10 gaps (week dates, comma fractional seconds) still land in
+    it silently — tracked as PARSE-ISO-ABSORBS in doc 84, and NOT closed by this fix.
     """
     if not value:
         return None
     try:
-        dt = datetime.fromisoformat(str(value))
+        return parse_iso_strict(value)
     except (TypeError, ValueError):
         return None
-    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
 
 
 def recency_score(signal: UsageSignal, created_at: str = "",

--- a/src/mokata/progress_events.py
+++ b/src/mokata/progress_events.py
@@ -481,12 +481,16 @@ def _event_age_hours(event: Dict[str, Any]) -> Optional[float]:
     ts = event.get("ts") if isinstance(event, dict) else None
     if not isinstance(ts, str) or not ts:
         return None
-    try:
-        when = datetime.fromisoformat(ts)
-    except ValueError:
+    # THE one ISO lexer (`memory.lifecycle.parse_iso`): same never-raise contract this function
+    # already had, same naive-is-UTC reading, and it lexes a `…Z` stamp on the declared 3.10 floor
+    # where a bare `fromisoformat` does not. Imported inside the function deliberately — this module
+    # loads today WITHOUT pulling `mokata.memory`, and a top-level import would drag that whole
+    # package (backends, embeddings, vector store) into every importer of this light module.
+    from .memory.lifecycle import parse_iso
+
+    when = parse_iso(ts)
+    if when is None:
         return None
-    if when.tzinfo is None:
-        when = when.replace(tzinfo=timezone.utc)        # a naive stamp is UTC, as `_now_iso` writes
     return (datetime.now(timezone.utc) - when).total_seconds() / 3600.0
 
 

--- a/tests/_iso_fixture.py
+++ b/tests/_iso_fixture.py
@@ -1,0 +1,33 @@
+"""Shared fixtures for the ISO-dialect pins: one instant, written two ways.
+
+Split out of the pin files themselves so P1 (the lexer) and P2 (the seven consumers) can live in
+SEPARATE modules. That separation is not cosmetic — `scripts/mutate.sh` selects tests by FILENAME,
+so two files is what lets a mutation verdict say "P1 caught it" or "only P2 caught it" instead of
+one undifferentiated red.
+
+Every fixture is written in the EXPLICIT `+00:00` dialect and converted by `zulu()`, so a test can
+never accidentally compare two different moments.
+
+Copyright 2026 MoStack. Licensed under the Apache License, Version 2.0.
+"""
+
+from __future__ import annotations
+
+NOW = "2026-07-29T12:00:00+00:00"
+ONE_HALF_LIFE_AGO = "2026-06-29T12:00:00+00:00"        # NOW - 30 days == RECENCY_HALF_LIFE_DAYS
+EXPIRED = "2026-07-28T12:00:00+00:00"                  # NOW - 1 day: a TTL that has elapsed
+UNEXPIRED = "2026-07-30T12:00:00+00:00"                # NOW + 1 day: a TTL that has NOT elapsed
+
+
+def explicit(iso: str) -> str:
+    """The explicit-offset dialect: the fixture as written."""
+    return iso
+
+
+def zulu(iso: str) -> str:
+    """The SAME instant in the Zulu dialect."""
+    assert iso.endswith("+00:00"), f"fixture must be written in the explicit dialect: {iso!r}"
+    return iso[: -len("+00:00")] + "Z"
+
+
+DIALECTS = (("explicit", explicit), ("zulu", zulu))

--- a/tests/test_ci_matrix_floor.py
+++ b/tests/test_ci_matrix_floor.py
@@ -1,0 +1,143 @@
+"""THE CI FLOOR GAP — the PR gate must exercise the interpreter version the package DECLARES.
+
+The finding this file guards, stated plainly: `pyproject.toml` promises `requires-python =
+">=3.10"`, but until 0.0.16 the only job that ever ran 3.10 was `release.yml`. The declared floor
+was therefore first exercised at TAG time — after review, after the work was called done, and at
+the one moment when a red is most expensive. That is not a testing gap in the abstract; it is the
+mechanism by which the ISO-dialect split shipped green. `datetime.fromisoformat` learned the Zulu
+designator in 3.11, so the fault existed ONLY below the CI floor, and a 3.12-only gate cannot see
+any bug of that shape by construction.
+
+Fixing one such bug does not close the hole. Pinning the floor into the PR gate does, which is
+what this file is for.
+
+WHAT IS AND IS NOT CLAIMED. One leg (ubuntu × floor × jsonschema=present) is not full matrix
+coverage of the floor, and this file does not pretend otherwise — it pins that the floor is
+exercised BEFORE tag, not that every axis is crossed with it. The broader treatment is tracked as
+CI-MATRIX-FLOOR-GAP in doc 84.
+
+Copyright 2026 MoStack. Licensed under the Apache License, Version 2.0.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import unittest
+
+import _support  # noqa: F401 - puts src/ on the path
+
+_ROOT = os.path.join(os.path.dirname(__file__), "..")
+PYPROJECT = os.path.join(_ROOT, "pyproject.toml")
+CI_YML = os.path.join(_ROOT, ".github", "workflows", "ci.yml")
+RELEASE_YML = os.path.join(_ROOT, ".github", "workflows", "release.yml")
+
+
+def _read(path: str) -> str:
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _declared_floor() -> str:
+    """The minimum Python `pyproject.toml` promises, e.g. '3.10'.
+
+    Read from the manifest rather than hard-coded, so RAISING the floor cannot leave this guard
+    silently pinning a version nobody supports any more.
+    """
+    match = re.search(r'requires-python\s*=\s*["\']>=\s*([0-9]+\.[0-9]+)', _read(PYPROJECT))
+    assert match, "pyproject.toml declares no `requires-python = \">=X.Y\"` floor"
+    return match.group(1)
+
+
+def _yaml():
+    try:
+        import yaml
+    except ImportError:                                  # pragma: no cover - env-dependent
+        return None
+    return yaml
+
+
+def _python_legs(doc) -> list:
+    """Every Python version the `test` job actually runs — the axis AND the `include` legs.
+
+    Reading only `matrix.python` would miss the floor leg entirely (it is an `include`), which is
+    exactly the kind of half-look that lets a guard pass while the thing it guards is absent.
+    """
+    matrix = doc["jobs"]["test"]["strategy"]["matrix"]
+    legs = [str(v) for v in matrix.get("python", [])]
+    for extra in matrix.get("include", []) or []:
+        if "python" in extra:
+            legs.append(str(extra["python"]))
+    return legs
+
+
+class TheDeclaredFloorRunsOnThePRGate(unittest.TestCase):
+    def setUp(self) -> None:
+        self.yaml = _yaml()
+        if self.yaml is None:
+            # A text `assertIn("3.10", ci_yml)` would match the EXPLANATORY COMMENT in that file
+            # and pass with no such leg configured. A guard that can be satisfied by prose is
+            # worse than no guard, so this skips honestly instead.
+            self.skipTest("PyYAML not installed — structural matrix assertions need a real parse")
+        self.doc = self.yaml.safe_load(_read(CI_YML))
+        self.floor = _declared_floor()
+
+    def test_a_the_floor_is_a_real_version_and_is_not_the_ci_default(self):
+        # Non-degeneracy for every test below: if the floor stopped parsing, or the project
+        # raised its floor to the version CI already ran, these assertions would pass for the
+        # wrong reason. Fail loudly on that day instead.
+        self.assertRegex(self.floor, r"^3\.\d+$")
+        self.assertEqual(self.floor, "3.10",
+                         "the declared floor moved — re-read this file's premise before editing it")
+
+    def test_b_the_pr_gate_runs_the_declared_floor(self):
+        legs = _python_legs(self.doc)
+        self.assertIn(self.floor, legs,
+                      f"ci.yml never runs py{self.floor}, the version pyproject.toml promises — "
+                      f"the floor would first be exercised at tag time. Legs found: {legs}")
+
+    def test_c_the_floor_leg_is_fully_specified(self):
+        # An `include` leg that omits `jsonschema` leaves every `if: matrix.jsonschema == …` step
+        # unmatched, so the leg would run a HOLLOW subset of the gate and still report green.
+        matrix = self.doc["jobs"]["test"]["strategy"]["matrix"]
+        floor_legs = [e for e in (matrix.get("include") or [])
+                      if str(e.get("python")) == self.floor]
+        self.assertEqual(len(floor_legs), 1, "expected exactly one floor leg")
+        leg = floor_legs[0]
+        for key in ("os", "jsonschema"):
+            self.assertIn(key, leg, f"the floor leg pins no `{key}` — its `if:` steps would skip")
+        self.assertEqual(leg["jsonschema"], "present")
+        self.assertEqual(leg["os"], "ubuntu-latest", "the floor leg belongs on the cheap runner")
+
+    def test_d_the_floor_did_not_REPLACE_the_primary_version(self):
+        # The cheap wrong fix: swap 3.12 for 3.10 and call the floor covered. Both must run.
+        legs = _python_legs(self.doc)
+        self.assertIn("3.12", legs, "the primary Python leg was dropped")
+
+    def test_e_the_floor_was_added_as_ONE_leg_not_a_cross_product(self):
+        # The gate is already ~45 min. Adding "3.10" to the `python:` axis would cross-product
+        # with os × jsonschema to 8 legs and roughly double it. This pins the cheap
+        # shape so a later edit cannot quietly double the gate.
+        matrix = self.doc["jobs"]["test"]["strategy"]["matrix"]
+        self.assertEqual([str(v) for v in matrix["python"]], ["3.12"],
+                         "the floor belongs in `include`, not on the `python` axis")
+        self.assertEqual(len(matrix.get("include") or []), 1)
+
+
+class TheReleaseGateStillCoversTheFloor(unittest.TestCase):
+    """The floor leg on the PR gate ADDS to release.yml; it must not have moved coverage."""
+
+    def test_a_release_still_runs_the_floor(self):
+        yaml = _yaml()
+        if yaml is None:
+            self.skipTest("PyYAML not installed")
+        doc = yaml.safe_load(_read(RELEASE_YML))
+        floor = _declared_floor()
+        versions = [str(v) for v in doc["jobs"]["test"]["strategy"]["matrix"]["python"]]
+        self.assertIn(floor, versions,
+                      "release.yml stopped running the declared floor")
+        self.assertGreater(len(versions), 1, "the release matrix collapsed to one version")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_iso_dialect_consumers.py
+++ b/tests/test_iso_dialect_consumers.py
@@ -1,0 +1,210 @@
+"""P2 — dialect EQUIVALENCE at all seven consumer sites of the ISO lexer.
+
+The property that actually matters: the dialect a timestamp is WRITTEN in must never change a
+decision mokata makes. Seven rows for the seven call sites the lexer feeds, table-driven so that
+adding a consumer without adding a row is the visible drift this file exists to catch.
+
+WHY EVERY ROW CARRIES A NON-DEGENERATE `expected`. `assertEqual(zulu, explicit)` on its own is
+satisfied by BOTH dialects returning 0.0 / None / () — i.e. by the very degradation being pinned
+against. On 3.10 before the fix, several of these sites returned the same wrong answer in both
+dialects and a bare equivalence check would have been GREEN. So each row also asserts the site did
+the work: a recency term of exactly 0.5 at one half-life, a TTL that actually FIRES, a timestamp
+that actually advanced. A pin that cannot distinguish "looked and found nothing" from "never
+looked" is not evidence.
+
+P1 (the lexer itself) lives in `test_iso_dialect_split.py`.
+
+Copyright 2026 MoStack. Licensed under the Apache License, Version 2.0.
+"""
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Optional
+
+import _support  # noqa: F401 - puts src/ on the path
+
+from _iso_fixture import (
+    DIALECTS,
+    EXPIRED,
+    NOW,
+    ONE_HALF_LIFE_AGO,
+    UNEXPIRED,
+    explicit,
+    zulu,
+)
+
+from mokata import progress_events
+from mokata.memory import healing, lifecycle
+from mokata.memory.item import MemoryItem, add_seconds
+
+Dialect = Callable[[str], str]
+
+
+# ===================================================================== the sites, exercised
+def _recency(recall_stamp: Optional[str], created_at: str, now: str) -> float:
+    return lifecycle.recency_score(
+        lifecycle.UsageSignal(hits=3, last_recalled_at=recall_stamp),
+        created_at=created_at, now=now)
+
+
+def _stale_proposals(expires_at: str, now: str) -> tuple:
+    item = MemoryItem.create(subject="ttl probe", value="v",
+                             created_at=ONE_HALF_LIFE_AGO, expires_at=expires_at)
+    return tuple(sorted((p.kind, p.subject) for p in healing.detect_issues([item], now=now)))
+
+
+def _event_age(ts: str) -> Optional[float]:
+    return progress_events._event_age_hours({"ts": ts})
+
+
+# The progress-events site reads `datetime.now()` INSIDE the call, so its two dialect runs are
+# milliseconds apart in real time. Its row is built off the wall clock and compared with a
+# tolerance; every other row is deterministic and compared exactly.
+_AGED_HOURS = 48.0
+
+
+def _aged_stamp() -> str:
+    return (datetime.now(timezone.utc) - timedelta(hours=_AGED_HOURS)).isoformat()
+
+
+@dataclass(frozen=True)
+class Site:
+    """One consumer of the lexer, runnable in either dialect."""
+
+    label: str
+    where: str
+    run: Callable[[Dialect], Any]
+    expected: Any
+    note: str
+    delta: Optional[float] = None
+
+
+SITES = (
+    Site(
+        label="recency_score / last_recalled_at",
+        where="lifecycle.py:139 (primary reference)",
+        run=lambda d: _recency(d(ONE_HALF_LIFE_AGO), created_at="", now=NOW),
+        expected=0.5,
+        note="exactly one half-life old, so the honest answer is 0.5; the absorbed-fault "
+             "answer is 0.0 and outranks nothing",
+    ),
+    Site(
+        label="recency_score / created_at fallback",
+        where="lifecycle.py:139 (fallback reference)",
+        run=lambda d: _recency(None, created_at=d(ONE_HALF_LIFE_AGO), now=NOW),
+        expected=0.5,
+        note="the fallback arm of the same line — reached only when an item has hits but no "
+             "recall stamp, which is exactly the half-landed-telemetry case",
+    ),
+    Site(
+        label="recency_score / now",
+        where="lifecycle.py:140 (the clock)",
+        run=lambda d: _recency(ONE_HALF_LIFE_AGO, created_at="", now=d(NOW)),
+        expected=0.5,
+        note="an unreadable `now` falls back to the REAL clock, so this site silently re-dates "
+             "the whole corpus rather than zeroing one item",
+    ),
+    Site(
+        label="healing.detect_issues / now",
+        where="healing.py:309",
+        run=lambda d: _stale_proposals(expires_at=EXPIRED, now=d(NOW)),
+        expected=((healing.STALE, "ttl probe"),),
+        note="an unreadable `now` yields ref=None, and then NO item in the store can ever be "
+             "proposed stale — the failure is corpus-wide, not per-item",
+    ),
+    Site(
+        label="healing.detect_issues / expires_at",
+        where="healing.py:313",
+        run=lambda d: _stale_proposals(expires_at=d(EXPIRED), now=NOW),
+        expected=((healing.STALE, "ttl probe"),),
+        note="the TTL must actually FIRE; the degraded answer is an empty proposal list, i.e. an "
+             "expired fact reads as live",
+    ),
+    Site(
+        label="item.add_seconds",
+        where="item.py:294 (raising contract)",
+        run=lambda d: add_seconds(d(NOW), 3600),
+        expected="2026-07-29T13:00:00+00:00",
+        note="the one site that RAISES rather than absorbing, so its failure is loud — but it "
+             "must still LEX the Zulu dialect rather than rejecting it",
+    ),
+    Site(
+        label="progress_events verdict age",
+        where="progress_events.py:485 (ship gate)",
+        run=lambda d: _event_age(d(_aged_stamp())),
+        expected=_AGED_HOURS,
+        delta=0.05,
+        note="None reads as STALE evidence at the ship gate, blocking a legitimate ship",
+    ),
+)
+
+
+class P2DialectEquivalenceAtEveryConsumer(unittest.TestCase):
+    def test_a_all_seven_call_sites_are_covered(self):
+        # The count is the claim; this guards the table against silently shrinking.
+        self.assertEqual(len(SITES), 7)
+        self.assertEqual(len({s.where for s in SITES}), 7, "two rows name the same call site")
+
+    def test_b_each_site_answers_identically_in_both_dialects(self):
+        for site in SITES:
+            with self.subTest(site=site.label):
+                z, e = site.run(zulu), site.run(explicit)
+                if site.delta is not None:
+                    self.assertAlmostEqual(z, e, delta=site.delta,
+                                           msg=f"{site.where}: dialect changed the answer")
+                else:
+                    self.assertEqual(z, e, f"{site.where}: dialect changed the answer")
+
+    def test_c_each_site_actually_did_the_work_in_both_dialects(self):
+        # The non-degeneracy half — without it, test_b is satisfied by both dialects failing
+        # identically, which is precisely the bug's signature on 3.10.
+        for site in SITES:
+            for name, dialect in DIALECTS:
+                with self.subTest(site=site.label, dialect=name):
+                    got = site.run(dialect)
+                    if site.delta is not None:
+                        self.assertAlmostEqual(got, site.expected, delta=site.delta,
+                                               msg=f"{site.where}: {site.note}")
+                    else:
+                        self.assertEqual(got, site.expected, f"{site.where}: {site.note}")
+
+
+class P2TheHealingRowsHaveANegativeControl(unittest.TestCase):
+    """A LIVE TTL must NOT propose stale — otherwise the two healing rows above are also
+    satisfied by a detector that proposes STALE for everything it is handed."""
+
+    def test_a_an_unexpired_zulu_ttl_produces_no_stale_proposal(self):
+        self.assertEqual(_stale_proposals(expires_at=zulu(UNEXPIRED), now=NOW), ())
+        self.assertEqual(_stale_proposals(expires_at=UNEXPIRED, now=zulu(NOW)), ())
+
+    def test_b_expired_and_live_differ_within_the_zulu_dialect(self):
+        expired = _stale_proposals(expires_at=zulu(EXPIRED), now=zulu(NOW))
+        live = _stale_proposals(expires_at=zulu(UNEXPIRED), now=zulu(NOW))
+        self.assertNotEqual(expired, live)
+        self.assertEqual(expired, ((healing.STALE, "ttl probe"),))
+
+
+class P2TheRecencyRowsHaveANegativeControl(unittest.TestCase):
+    """0.5 must be EARNED by the age, not returned for any input — otherwise the three recency
+    rows would pass against a function that ignores its timestamps."""
+
+    def test_a_a_different_age_scores_differently_in_the_zulu_dialect(self):
+        two_half_lives = "2026-05-30T12:00:00+00:00"        # NOW - 60 days
+        self.assertAlmostEqual(
+            _recency(zulu(two_half_lives), created_at="", now=zulu(NOW)), 0.25, places=6)
+
+    def test_b_zero_hits_still_scores_zero_in_either_dialect(self):
+        # The DB.S5 back-compat floor, re-pinned here: the fix must not switch the recency term on
+        # for a never-recalled item just because its stamp is now readable.
+        for name, dialect in DIALECTS:
+            with self.subTest(dialect=name):
+                signal = lifecycle.UsageSignal(hits=0, last_recalled_at=dialect(ONE_HALF_LIFE_AGO))
+                self.assertEqual(
+                    lifecycle.recency_score(signal, created_at="", now=dialect(NOW)), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_iso_dialect_split.py
+++ b/tests/test_iso_dialect_split.py
@@ -1,0 +1,128 @@
+"""P1 — the ONE ISO lexer, pinned directly. The mutation-provable half.
+
+THE BUG. `datetime.fromisoformat` only learned the Zulu designator ('…Z') in Python 3.11. mokata's
+declared floor is 3.10, where every `…Z` stamp raises ValueError — and at most consumer sites that
+fault was ABSORBED to None by `lifecycle.parse_iso`, degrading a real signal to 0.0 with nothing
+logged and nothing failing. The ranking was quietly wrong on the interpreter the package claims to
+support, and branch CI (3.12 only) was structurally unable to see it.
+
+WHY THESE PINS ARE ON THE LEXER'S TEXT, not on parsed results. `_normalize_iso` maps string to
+string, so its expected output is FIXED TEXT that does not depend on what the running interpreter
+can parse. These tests therefore fail on 3.12 exactly as loudly as on 3.10 — which is the entire
+point of pinning here. A fix gated behind `sys.version_info` would leave the 3.10 branch green-by-
+absence on every CI run between releases; a pin that only bites on the interpreter CI does not run
+is not a guard. If P1 ever passes on one interpreter and fails on the other, the fix has been
+version-gated and the gate is the bug.
+
+P2 (the seven consumer sites) lives in `test_iso_dialect_consumers.py` — separate file so a
+mutation verdict can name which half caught it.
+
+Copyright 2026 MoStack. Licensed under the Apache License, Version 2.0.
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+import _support  # noqa: F401 - puts src/ on the path
+
+from _iso_fixture import NOW, zulu
+
+from mokata.memory import lifecycle
+
+
+class P1TheLexer(unittest.TestCase):
+    """`_normalize_iso` rewrites the Zulu designator and touches NOTHING else."""
+
+    def test_a_trailing_capital_z_becomes_the_explicit_utc_offset(self):
+        self.assertEqual(lifecycle._normalize_iso("2026-01-01T00:00:00Z"),
+                         "2026-01-01T00:00:00+00:00")
+
+    def test_b_trailing_lowercase_z_becomes_the_explicit_utc_offset(self):
+        # RFC 3339 says the designator is case-insensitive; hand-edited docs and some clients emit
+        # the lowercase form, so the lexer must not be a `.endswith("Z")` half-measure.
+        self.assertEqual(lifecycle._normalize_iso("2026-01-01T00:00:00z"),
+                         "2026-01-01T00:00:00+00:00")
+
+    def test_c_an_already_explicit_utc_offset_is_untouched(self):
+        stamp = "2026-01-01T00:00:00+00:00"
+        self.assertEqual(lifecycle._normalize_iso(stamp), stamp)
+
+    def test_d_a_non_utc_offset_is_untouched(self):
+        # Catches a lexer that "normalizes to UTC" rather than rewriting a designator: +05:30 is a
+        # DIFFERENT instant and must survive byte-identical.
+        stamp = "2026-01-01T00:00:00+05:30"
+        self.assertEqual(lifecycle._normalize_iso(stamp), stamp)
+
+    def test_e_a_naive_stamp_is_untouched(self):
+        stamp = "2026-01-01T00:00:00"
+        self.assertEqual(lifecycle._normalize_iso(stamp), stamp)
+
+    def test_f_degenerate_inputs_do_not_crash_the_lexer(self):
+        # The lexer sits AHEAD of the absorber, so anything it raises escapes a path whose contract
+        # is "never raises". It must be total over junk, and leave junk as junk for the parser.
+        self.assertEqual(lifecycle._normalize_iso("Z"), "Z")     # a bare designator is not a stamp
+        self.assertEqual(lifecycle._normalize_iso(""), "")
+        self.assertIsNone(lifecycle._normalize_iso(None))
+
+    def test_g_the_normalized_text_parses_to_the_same_instant(self):
+        # The lexer's output is TEXT; this is the pin that the text actually parses, on THIS
+        # interpreter, to the same aware moment as the explicit dialect.
+        self.assertEqual(lifecycle.parse_iso_strict(zulu(NOW)), lifecycle.parse_iso_strict(NOW))
+        self.assertEqual(lifecycle.parse_iso_strict(zulu(NOW)),
+                         datetime(2026, 7, 29, 12, 0, tzinfo=timezone.utc))
+
+
+class P1TheWrapperContracts(unittest.TestCase):
+    """Both wrappers route through the lexer, and their raise/absorb contracts are UNCHANGED."""
+
+    def test_a_strict_routes_zulu_through_the_lexer(self):
+        # RED if `parse_iso_strict` calls `fromisoformat` directly again.
+        self.assertEqual(lifecycle.parse_iso_strict(zulu(NOW)),
+                         datetime(2026, 7, 29, 12, 0, tzinfo=timezone.utc))
+
+    def test_b_lenient_routes_zulu_through_the_lexer(self):
+        # RED if `parse_iso` stops delegating to `parse_iso_strict`.
+        self.assertEqual(lifecycle.parse_iso(zulu(NOW)),
+                         datetime(2026, 7, 29, 12, 0, tzinfo=timezone.utc))
+
+    def test_c_strict_still_RAISES_on_genuinely_malformed_input(self):
+        # The contract split is the whole reason there are two wrappers. If strict stopped raising,
+        # `item.add_seconds` would silently compute a TTL off a stamp it could not read.
+        for junk in ("not-a-timestamp", "Z", "", None):
+            with self.subTest(junk=junk):
+                with self.assertRaises((TypeError, ValueError)):
+                    lifecycle.parse_iso_strict(junk)
+
+    def test_d_lenient_still_NEVER_raises(self):
+        for junk in ("not-a-timestamp", "Z", "2026-13-45T99:99:99Z", "", None, 17, object()):
+            with self.subTest(junk=junk):
+                self.assertIsNone(lifecycle.parse_iso(junk))
+
+    def test_e_a_naive_stamp_is_read_as_utc_by_both_wrappers(self):
+        naive = "2026-07-29T12:00:00"
+        self.assertEqual(lifecycle.parse_iso_strict(naive), lifecycle.parse_iso(NOW))
+        self.assertEqual(lifecycle.parse_iso(naive), lifecycle.parse_iso(NOW))
+
+
+class P1TheFixIsNotVersionGated(unittest.TestCase):
+    """The normalization is UNCONDITIONAL — no interpreter branch in this path.
+
+    Pinned structurally as well as behaviourally, because the behavioural pins above cannot by
+    themselves distinguish "unconditional" from "conditional and this interpreter took the good
+    branch". Two lexers is the failure mode: whichever one CI does not run is the one that rots.
+    """
+
+    def test_a_the_lexer_source_contains_no_interpreter_branch(self):
+        import inspect
+
+        source = inspect.getsource(lifecycle._normalize_iso)
+        for gate in ("version_info", "sys.version", "PY3", "platform."):
+            self.assertNotIn(gate, source,
+                             f"`_normalize_iso` branches on {gate!r} — a version-gated fix ships "
+                             f"two lexers and hides one from CI")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_iso_mixed_vintage_expiry.py
+++ b/tests/test_iso_mixed_vintage_expiry.py
@@ -1,0 +1,213 @@
+"""P3 — MIXED VINTAGE: a store holding both shapes of `expires_at` decides identically.
+
+`item.add_seconds` changed shape in 0.0.16. It routes through `lifecycle.parse_iso_strict`, which
+reads a NAIVE stamp AS UTC and hands back an aware datetime — so `.isoformat()` now emits an
+explicit `+00:00` where 0.0.15's bare `datetime.fromisoformat` emitted a naive stamp:
+
+    add_seconds("2026-07-01T06:00:00", 3600)   0.0.15 -> "2026-07-01T07:00:00"
+                                               0.0.16 -> "2026-07-01T07:00:00+00:00"
+
+Only the NAIVE input dialect moved. `+00:00` and other explicit offsets were byte-identical before
+and after; `…Z` RAISED on the declared 3.10 floor, so it wrote no row at all to be mixed with.
+
+That means a store written by 0.0.15 and reopened by 0.0.16 holds BOTH shapes at once, naming the
+SAME instant, for the rest of its life — there is no migration and deliberately none, because the
+audit found nothing that can observe the difference: `expires_at` is not a COLUMN in either backend
+(it lives inside the `doc` JSON, so neither Postgres TIMESTAMP truncation nor SQLite's TEXT
+lexicographic compare can reach it), and no read path compares, sorts or keys it as a raw string.
+`migrate.item_digest` hashes only id/mtype/subject/value/status, so the batch-derivation guard does
+not see it either.
+
+"Nothing can observe it" is a claim about the whole read surface, and this file is what makes it
+FALSIFIABLE rather than merely asserted. Three decisions, each run against both vintages of the one
+instant, each required to come out the same:
+
+  V1  TTL EXPIRY   — `detect_issues` fires STALE for both, or neither, on each side of the instant.
+  V2  ORDERING     — parsed instants compare EQUAL, and a later item sorts after both regardless of
+                     vintage. This is the one with teeth: as TEXT, "…T07:00:00" is a PREFIX of
+                     "…T07:00:00+00:00" and therefore sorts FIRST, so a raw-string sort separates
+                     two stamps that name the same moment.
+  V3  LOOKUP       — a real SQLite store round-trips both, `get`/`all` return them intact, and the
+                     doc key set is identical, so neither vintage is a differently-shaped doc.
+
+The naive row is written through the STORE with a hand-written stamp (`MemoryItem(...)` direct,
+which is what a 0.0.15 write left on disk), never through `create`, so the fixture cannot silently
+start testing 0.0.16 against itself if `add_seconds` changes again.
+
+P1 (the lexer) is `test_iso_dialect_split.py`; P2 (consumer equivalence) is
+`test_iso_dialect_consumers.py`.
+
+Copyright 2026 MoStack. Licensed under the Apache License, Version 2.0.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import _support  # noqa: F401 - puts src/ on the path
+
+from mokata.memory.backends import SQLiteBackend
+from mokata.memory.healing import STALE, detect_issues
+from mokata.memory.item import ACTIVE, PERSISTENT, MemoryItem, add_seconds
+from mokata.memory.lifecycle import parse_iso, parse_iso_strict
+
+# ONE instant, in the two vintages. `_CREATED` + one hour is `_INSTANT`, which is what makes the
+# 0.0.16 row genuinely a product of the new write path rather than a hand-typed twin of it.
+_CREATED = "2026-07-01T06:00:00"                  # naive, as a 0.0.15 caller supplied it
+_INSTANT_NAIVE = "2026-07-01T07:00:00"            # what 0.0.15's add_seconds stored
+_INSTANT_AWARE = "2026-07-01T07:00:00+00:00"      # what 0.0.16's add_seconds stores
+
+_BEFORE = "2026-07-01T06:30:00+00:00"             # both rows still LIVE here
+_AFTER = "2026-07-01T07:30:00+00:00"              # both rows EXPIRED here
+
+# THE BOUNDARY, and the only `now` at which a raw-string compare actually SPLITS the two vintages.
+# It has to be the instant itself: away from it the hour digits dominate the compare and text and
+# instants happen to agree, which is why an off-boundary pin lets a string-compare regression
+# through (this file's first draft did, and the mutant survived). Here:
+#
+#   "2026-07-01T07:00:00"        >= "2026-07-01T07:00:00+00:00"  -> False as TEXT (a prefix is
+#                                                                   LESS) -> legacy read EXPIRED
+#   "2026-07-01T07:00:00+00:00"  >= "2026-07-01T07:00:00+00:00"  -> True  -> current read LIVE
+#
+# As instants both are `>= now`, so the correct answer is NEITHER stale — the same answer for both.
+_AT = _INSTANT_AWARE
+
+
+def _legacy_item(item_id: str) -> MemoryItem:
+    """A row exactly as 0.0.15 left it: a naive `expires_at`, built without `create`."""
+    return MemoryItem(subject=f"host {item_id}", value="10.0.0.1", id=item_id,
+                      mtype=PERSISTENT, status=ACTIVE, expires_at=_INSTANT_NAIVE,
+                      provenance={"source": "test", "author": "t", "created_at": _CREATED})
+
+
+def _current_item(item_id: str) -> MemoryItem:
+    """A row written by THIS build's path — `create` -> `add_seconds` -> aware stamp."""
+    return MemoryItem.create(subject=f"host {item_id}", value="10.0.0.1", id=item_id,
+                             source="test", author="t", created_at=_CREATED, valid_for=3600)
+
+
+class TestFixtureIsHonest(unittest.TestCase):
+    """The fixture's own preconditions. If these drift, every assertion below is vacuous."""
+
+    def test_the_two_vintages_are_textually_different(self):
+        self.assertNotEqual(_INSTANT_NAIVE, _INSTANT_AWARE,
+                            "mixed vintage is only a hazard if the two stamps differ as text")
+
+    def test_the_two_vintages_name_the_same_instant(self):
+        self.assertEqual(parse_iso_strict(_INSTANT_NAIVE), parse_iso_strict(_INSTANT_AWARE),
+                         "the whole premise: one moment, written two ways")
+
+    def test_this_build_writes_the_aware_vintage(self):
+        self.assertEqual(add_seconds(_CREATED, 3600), _INSTANT_AWARE)
+        self.assertEqual(_current_item("c").expires_at, _INSTANT_AWARE,
+                         "if create() stops emitting the aware shape this file is comparing "
+                         "0.0.15 against itself and proves nothing")
+
+    def test_the_legacy_row_is_not_built_through_the_new_path(self):
+        self.assertEqual(_legacy_item("l").expires_at, _INSTANT_NAIVE)
+
+
+# --------------------------------------------------------------------------- V1  TTL expiry
+class TestV1TtlExpiry(unittest.TestCase):
+    """Both vintages must fire STALE together and stay live together."""
+
+    def _kinds(self, item, now):
+        return [p.kind for p in detect_issues([item], now=now)]
+
+    def test_both_vintages_are_live_before_the_instant(self):
+        self.assertNotIn(STALE, self._kinds(_legacy_item("l"), _BEFORE))
+        self.assertNotIn(STALE, self._kinds(_current_item("c"), _BEFORE))
+
+    def test_both_vintages_are_stale_after_the_instant(self):
+        self.assertIn(STALE, self._kinds(_legacy_item("l"), _AFTER),
+                      "a 0.0.15 naive TTL must still expire — read as UTC, not dropped")
+        self.assertIn(STALE, self._kinds(_current_item("c"), _AFTER))
+
+    def test_at_the_boundary_neither_vintage_is_stale(self):
+        """The load-bearing case. A raw-string compare calls the LEGACY row expired here and the
+        current one live — the same instant, two verdicts, decided by which build wrote it."""
+        self.assertNotIn(STALE, self._kinds(_legacy_item("l"), _AT),
+                         "a naive stamp equal to `now` must not read as already expired")
+        self.assertNotIn(STALE, self._kinds(_current_item("c"), _AT))
+
+    def test_the_two_vintages_agree_row_for_row_in_one_pass(self):
+        """Both in ONE detection pass, which is how a real mixed store is actually read."""
+        for now, expect_stale in ((_BEFORE, False), (_AT, False), (_AFTER, True)):
+            with self.subTest(now=now):
+                stale = {p.subject for p in detect_issues(
+                    [_legacy_item("l"), _current_item("c")], now=now) if p.kind == STALE}
+                self.assertEqual(stale, {"host l", "host c"} if expect_stale else set(),
+                                 "one vintage expired while the other did not")
+
+
+# --------------------------------------------------------------------------- V2  ordering
+class TestV2Ordering(unittest.TestCase):
+    """Ordering by expiry must be by INSTANT. The raw-string sort is the failure being pinned."""
+
+    def test_the_raw_string_sort_disagrees_with_the_instant_sort(self):
+        """The negative control. Without this, V2 could pass because sorting is a no-op here."""
+        self.assertLess(_INSTANT_NAIVE, _INSTANT_AWARE,
+                        "as TEXT the naive stamp is a PREFIX and sorts first — that is the bug "
+                        "this class exists to keep out")
+
+    def test_the_two_vintages_compare_equal_as_instants(self):
+        self.assertEqual(parse_iso(_legacy_item("l").expires_at),
+                         parse_iso(_current_item("c").expires_at))
+
+    def test_a_later_row_sorts_after_both_vintages(self):
+        later = MemoryItem(subject="host z", value="v", id="z", mtype=PERSISTENT, status=ACTIVE,
+                           expires_at="2026-07-01T08:00:00+00:00",
+                           provenance={"source": "test", "author": "t", "created_at": _CREATED})
+        for first in (_legacy_item("l"), _current_item("c")):
+            with self.subTest(vintage=first.expires_at):
+                ordered = sorted([later, first], key=lambda i: parse_iso(i.expires_at))
+                self.assertEqual([i.id for i in ordered], [first.id, "z"],
+                                 "expiry order must not depend on which vintage wrote the stamp")
+
+
+# --------------------------------------------------------------------------- V3  lookup
+class TestV3StoreRoundTrip(unittest.TestCase):
+    """A REAL store holding both vintages at once — the mixed store the audit was about."""
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        self.store = SQLiteBackend(os.path.join(self.root, "memory.db"))
+        self.addCleanup(self.store.close)
+        self.store.put(_legacy_item("legacy"))
+        self.store.put(_current_item("current"))
+
+    def test_each_vintage_survives_get_byte_for_byte(self):
+        self.assertEqual(self.store.get("legacy").expires_at, _INSTANT_NAIVE,
+                         "the store must not silently rewrite a legacy stamp")
+        self.assertEqual(self.store.get("current").expires_at, _INSTANT_AWARE)
+
+    def test_both_vintages_come_back_from_all(self):
+        got = {i.id: i.expires_at for i in self.store.all()}
+        self.assertEqual(got, {"legacy": _INSTANT_NAIVE, "current": _INSTANT_AWARE})
+
+    def test_the_two_vintages_are_the_same_doc_SHAPE(self):
+        """Same keys, differing only in the stamp — neither vintage is a differently-shaped doc."""
+        legacy, current = self.store.get("legacy").to_dict(), self.store.get("current").to_dict()
+        self.assertEqual(set(legacy), set(current))
+        self.assertEqual({k: v for k, v in legacy.items() if k not in ("id", "subject",
+                                                                       "expires_at")},
+                         {k: v for k, v in current.items() if k not in ("id", "subject",
+                                                                        "expires_at")})
+
+    def test_a_mixed_store_expires_both_rows_together(self):
+        """The end-to-end shape: read the mixed store back, then decide TTL over what came out."""
+        rows = sorted(self.store.all(), key=lambda i: i.id)
+        for now, expect in ((_BEFORE, set()), (_AT, set()),
+                            (_AFTER, {"host current", "host legacy"})):
+            with self.subTest(now=now):
+                stale = {p.subject for p in detect_issues(rows, now=now) if p.kind == STALE}
+                self.assertEqual(stale, expect,
+                                 "a mixed-vintage store must not expire one row and not the other")
+
+
+if __name__ == "__main__":                        # pragma: no cover
+    unittest.main()

--- a/tests/test_stage68_supply_chain.py
+++ b/tests/test_stage68_supply_chain.py
@@ -381,20 +381,40 @@ class TestSyncPublicBoundaryHardened(unittest.TestCase):
     stay in step)."""
 
     # The seven long-standing internal paths + the three regenerable/backup artifacts added in
-    # Stage 3c.2. Each must appear in BOTH the rsync --exclude list and the INTERNAL_PATHS guard.
+    # Stage 3c.2 + `_to_delete/` (TODELETE-LEAK, 0.0.16) + the VS Code extension's build
+    # artifacts (NODE_MODULES-LEAK, 0.0.16). Each must appear in BOTH the rsync --exclude list
+    # and the INTERNAL_PATHS guard.
     REQUIRED = (
         "docs/build", "docs/launch", "docs/marketing", "docs/talks", "CLAUDE.md",
         "scripts/sync-public.sh", "scripts/release.sh",
         "build", "dist", "release-backup-*",
+        "_to_delete",
+        "editors/vscode/node_modules", "editors/vscode/out",
     )
+
+    @staticmethod
+    def _code_only(block):
+        """`block` with every `#` comment line dropped.
+
+        Load-bearing, not tidiness. Both controls are documented IN PLACE, and those comments name
+        the very paths being pinned — the `_to_delete` entry sits under six lines of prose that say
+        "_to_delete" four times. A raw substring check therefore passes on the COMMENT after the
+        array entry it describes has been deleted, which is a pin that reports GREEN precisely when
+        the control it guards is gone. Caught by mutation (TD-2 survived until this stripped)."""
+        return "\n".join(ln for ln in block.splitlines() if not ln.lstrip().startswith("#"))
 
     def setUp(self):
         self.sh = _read(SYNC_SH)
         # Isolate the two controls so we assert against each independently.
         guard_start = self.sh.find("INTERNAL_PATHS=(")
         self.assertNotEqual(guard_start, -1, "sync-public.sh lost its INTERNAL_PATHS guard")
-        self.exclude_block = self.sh[:guard_start]
-        self.guard_block = self.sh[guard_start:]
+        # The guard is the ARRAY LITERAL, not "everything after it" — the array is followed by the
+        # enforcement loop and its commentary, which mention internal paths in prose and would
+        # otherwise satisfy a membership check on their own.
+        guard_end = self.sh.find("\n)", guard_start)
+        self.assertNotEqual(guard_end, -1, "INTERNAL_PATHS array is unterminated")
+        self.exclude_block = self._code_only(self.sh[:guard_start])
+        self.guard_block = self._code_only(self.sh[guard_start:guard_end])
 
     def test_exclude_list_covers_every_internal_path(self):
         for p in self.REQUIRED:
@@ -411,6 +431,53 @@ class TestSyncPublicBoundaryHardened(unittest.TestCase):
         for p in ("build", "dist", "release-backup-*"):
             self.assertIn(p, self.exclude_block, "missing --exclude for '" + p + "'")
             self.assertIn(p, self.guard_block, "missing INTERNAL_PATHS entry for '" + p + "'")
+
+    def test_to_delete_scratch_is_in_BOTH_places(self):
+        """TODELETE-LEAK (0.0.16). `_to_delete/` held 1.2GB of snapshot tarballs, ~90 git lock
+        files and `_secrets_before.py` — mokata's OWN source module, sitting untracked at the repo
+        root. `.gitignore` covered it and that is EXACTLY why it was dangerous: rsync copies the
+        working tree and ignores `.gitignore`, so the gitignore entry made the directory invisible
+        to `git status` while leaving it fully live to the mirror.
+
+        Asserted as its own case, not only as a `REQUIRED` row, because the two controls fail
+        DIFFERENTLY and the failure text has to say which one went missing: losing the `--exclude`
+        leaks the bytes, losing the `INTERNAL_PATHS` entry removes the backstop that would have
+        caught it. Both directions are mutation-proven."""
+        self.assertIn("_to_delete", self.exclude_block,
+                      "sync-public.sh lost its `--exclude='_to_delete/'` — scratch (and the "
+                      "`_secrets_before.py` that lived in it) would rsync to the public mirror")
+        self.assertIn("_to_delete", self.guard_block,
+                      "sync-public.sh lost `_to_delete` from INTERNAL_PATHS — the hard-guard "
+                      "would no longer abort a sync that carried it")
+
+    def test_vscode_build_artifacts_are_in_BOTH_places(self):
+        """NODE_MODULES-LEAK (0.0.16). Found by re-running TODELETE-LEAK's question against the
+        rest of the tree: `editors/vscode/node_modules/` (240 files, 26MB of third-party npm
+        packages) and `editors/vscode/out/` (10 compiled JS artifacts) were in NEITHER control.
+
+        WHAT ACTUALLY HAPPENED, measured rather than assumed — and it is the reason this case
+        exists. All 250 files WERE copied into the public checkout (they are in the 1126-file
+        dry-run manifest), but they never reached the public repo: `.gitignore` is itself mirrored,
+        so its lines 64-66 were sitting in the DEST checkout and `git add -A` skipped them.
+
+        So the only thing standing between 26MB of vendored dependencies and the public repo was
+        an ignore file that exists for an unrelated reason and is one edit from being changed —
+        no sync control named these paths at all. That is an accident, not a control: `git add -f`,
+        a decision to vendor the extension, or any tidy-up of those three lines publishes the lot,
+        and nothing in `sync-public.sh` would have said a word. Both dirs are regenerable
+        (`npm ci && npm run compile`), so the mirror loses nothing by dropping them.
+
+        Asserted as its own case for the same reason `_to_delete` is: the two controls fail
+        DIFFERENTLY and the message must say which one went missing. All four directions
+        mutation-proven independently via `scripts/mutate.sh`."""
+        for p in ("editors/vscode/node_modules", "editors/vscode/out"):
+            self.assertIn(p, self.exclude_block,
+                          "sync-public.sh lost its `--exclude='" + p + "/'` — the VS Code "
+                          "extension's build artifacts would rsync to the public mirror "
+                          "(.gitignore does NOT govern what rsync copies)")
+            self.assertIn(p, self.guard_block,
+                          "sync-public.sh lost `" + p + "` from INTERNAL_PATHS — the hard-guard "
+                          "would no longer catch a sync that carried it")
 
 
 if __name__ == "__main__":

--- a/tests/test_tm_s12a_branch_protection.py
+++ b/tests/test_tm_s12a_branch_protection.py
@@ -16,6 +16,13 @@ import os
 import unittest
 from contextlib import redirect_stdout
 
+try:                                        # test-only dep (requirements/ci.txt), not a mokata dep
+    import yaml
+    _HAVE_YAML = True
+except ImportError:                         # absence is FAILED LOUD at the pin, never skipped
+    yaml = None
+    _HAVE_YAML = False
+
 import _support  # noqa: F401  (puts src/ on the path)
 
 from mokata.branch_protection import (
@@ -210,42 +217,112 @@ class ReleaseScriptWiring(unittest.TestCase):
                      "scripts/sync-public.sh is dev-only — not shipped to the public mirror")
 class SyncBoundaryEnvHardening(unittest.TestCase):
     """scripts/sync-public.sh: a real `.env` is EXCLUDED (would carry live creds) but `.env.example`
-    still SHIPS, and .env is in the guard's INTERNAL_PATHS. (String-level: the DRY-RUN is the proof.)"""
+    still SHIPS, and .env is in the guard's INTERNAL_PATHS. (String-level: the DRY-RUN is the proof.)
+
+    PIN-SUBSTRING-COMMENT-HOLE (0.0.16). All three pins below used to grep the WHOLE script — and
+    the script documents both controls IN PLACE, in prose that names the very literals being
+    pinned (`sync-public.sh:104-112` says `.env` six times and quotes `'.env*'`). So each pin was
+    satisfied by the COMMENT after the control it guards had been deleted: green precisely when
+    the control was gone, and for all three this class was the SOLE guard. Mutation-proven, then
+    fixed with the TD-2 remedy — bound the slice to the rsync ARGUMENT literal / the INTERNAL_PATHS
+    ARRAY literal, and strip `#` lines from both before asserting."""
+
+    @staticmethod
+    def _code_only(block):
+        """`block` with every `#` comment line dropped. Load-bearing, not tidiness — see the
+        class docstring: the comments in this script name the exact literals under pin."""
+        return "\n".join(ln for ln in block.splitlines() if not ln.lstrip().startswith("#"))
+
+    @staticmethod
+    def _slice(text, start_marker, end_marker, what):
+        """`text` between the two markers. Raises (never returns a wrong slice) if either marker
+        is gone — an explicit raise, not `assert`, so `python -O` cannot delete the check."""
+        start = text.find(start_marker)
+        if start == -1:
+            raise AssertionError("sync-public.sh lost its " + what + " (no '" + start_marker + "')")
+        end = text.find(end_marker, start + len(start_marker))
+        if end == -1:
+            raise AssertionError("sync-public.sh's " + what + " is unterminated (no '"
+                                 + end_marker.replace("\n", "\\n") + "')")
+        return text[start:end]
 
     @classmethod
     def setUpClass(cls):
         with open(_SYNC_SH, encoding="utf-8") as fh:
             cls.sh = fh.read()
+        # The rsync ARGUMENT literal: `rsync -a --delete \` … `"$SRC"/ "$DEST"/`.
+        cls.rsync_args = cls._code_only(
+            cls._slice(cls.sh, "rsync -a --delete", '"$SRC"/ "$DEST"/', "rsync invocation"))
+        # The INTERNAL_PATHS ARRAY literal: `INTERNAL_PATHS=(` … `\n)`. Bounded on purpose —
+        # "everything after `INTERNAL_PATHS=(`" swallows the enforcement loop and its commentary,
+        # which discuss `.env` at length and satisfy the membership check on their own.
+        cls.guard_block = cls._code_only(
+            cls._slice(cls.sh, "INTERNAL_PATHS=(", "\n)", "INTERNAL_PATHS guard"))
 
     def test_env_example_is_included_before_env_exclude(self):
-        inc = self.sh.find("--include='.env.example'")
-        exc = self.sh.find("--exclude='.env")
+        inc = self.rsync_args.find("--include='.env.example'")
+        exc = self.rsync_args.find("--exclude='.env")
         self.assertNotEqual(inc, -1, ".env.example must be explicitly INCLUDED so it still ships")
         self.assertNotEqual(exc, -1, ".env must be EXCLUDED")
         self.assertLess(inc, exc,
                         "rsync ordering: the .env.example include must precede the .env exclude")
 
     def test_dotenv_wildcard_excluded(self):
-        self.assertIn("--exclude='.env*'", self.sh)
+        self.assertIn("--exclude='.env*'", self.rsync_args,
+                      "sync-public.sh lost its `--exclude='.env*'` rsync argument — a real .env "
+                      "(live DB creds) would be copied to the public mirror")
 
     def test_env_in_guard_internal_paths(self):
-        guard = self.sh[self.sh.find("INTERNAL_PATHS=("):]
-        self.assertIn(".env", guard, ".env must be in the guard's INTERNAL_PATHS")
+        # Token-level, not substring: `.env` must be an ARRAY ENTRY of its own. The array also
+        # holds `.venv` and `'*.egg-info'`, and a looser check invites a future near-miss.
+        self.assertIn(".env", self.guard_block.split(),
+                      ".env must be an entry in the guard's INTERNAL_PATHS — it is the "
+                      "belt-and-suspenders backstop for the live-credential file")
 
 
 class ScorecardPatWiring(unittest.TestCase):
-    """scorecard.yml must pass the SCORECARD_PAT to scorecard-action, keeping the SHA pin + trigger."""
+    """scorecard.yml must pass the SCORECARD_PAT to scorecard-action, keeping the SHA pin + trigger.
+
+    PIN-SUBSTRING-COMMENT-HOLE (0.0.16): `assertIn(<literal>, self.yml)` over the raw file passed
+    on the comment left behind when the real line was commented out — the SHA pin stayed green
+    with the action re-pointed at the MUTABLE `@v2` tag. Both pins now read the PARSED structure,
+    where a comment cannot appear. PyYAML is not a mokata dependency, so its absence is FAILED
+    LOUD rather than skipped: a pin that evaporates when a dep is missing is the same bug in a
+    different costume. CI installs it (requirements/ci.txt) for exactly this reason."""
+
+    _ACTION = "ossf/scorecard-action"
+    _SHA = "4eaacf0543bb3f2c246792bd56e8cdeffafb205a"
 
     @classmethod
     def setUpClass(cls):
         with open(os.path.join(ROOT, ".github", "workflows", "scorecard.yml"), encoding="utf-8") as fh:
             cls.yml = fh.read()
 
+    def _scorecard_step(self):
+        """The PARSED `ossf/scorecard-action` step. Fails loud without PyYAML."""
+        if not _HAVE_YAML:
+            self.fail("PyYAML is required to verify the scorecard-action wiring from the PARSED "
+                      "workflow (a text-level check passes on a comment). Install it: "
+                      "pip install -r requirements/ci.txt")
+        doc = yaml.safe_load(self.yml)
+        for job in (doc.get("jobs") or {}).values():
+            for step in (job or {}).get("steps") or []:
+                if self._ACTION in str((step or {}).get("uses", "")):
+                    return step
+        self.fail("scorecard.yml declares no `" + self._ACTION + "` step at all")
+
     def test_repo_token_wired_to_pat_secret(self):
-        self.assertIn("repo_token: ${{ secrets.SCORECARD_PAT }}", self.yml)
+        with_ = self._scorecard_step().get("with") or {}
+        self.assertEqual(with_.get("repo_token"), "${{ secrets.SCORECARD_PAT }}",
+                         "scorecard-action must receive the fine-grained SCORECARD_PAT; without it "
+                         "the Branch-Protection check scores 0 ('Resource not accessible')")
 
     def test_sha_pin_intact(self):
-        self.assertIn("4eaacf0543bb3f2c246792bd56e8cdeffafb205a", self.yml)
+        uses = str(self._scorecard_step().get("uses", ""))
+        ref = uses.split("@", 1)[1] if "@" in uses else ""
+        self.assertEqual(ref, self._SHA,
+                         "scorecard-action must stay pinned to its immutable 40-hex commit SHA, "
+                         "not a mutable tag — got '" + uses + "'")
 
     def test_trigger_intact(self):
         self.assertIn("branches: [main, master]", self.yml)


### PR DESCRIPTION
Re-sync of 0.0.16 after PR #37: that merge predates the ISO-dialect fix found at tag time.

Contents beyond #37:
- `lifecycle.py` — one ISO lexer (`_normalize_iso` + `parse_iso_strict`), closing the Python 3.10 Zulu (`…Z`) gap at its source. Not version-gated.
- Routed `item.add_seconds` (strict) and `progress_events._event_age_hours` (absorbing).
- `ci.yml` — one `ubuntu-latest × 3.10` leg on the PR gate, so the declared floor (`requires-python = ">=3.10"`) is exercised before tag time rather than at it.
- 26 new dialect/consumer pins + `test_ci_matrix_floor.py`; supply-chain and branch-protection pins tightened.

Local verification: full unit suite green on both interpreters — `Ran 5714 … OK` on 3.10 and on 3.12.